### PR TITLE
fix(source-tests): use github.rest.checks instead of github.checks

### DIFF
--- a/.github/workflows/source-tests.yml
+++ b/.github/workflows/source-tests.yml
@@ -175,7 +175,7 @@ jobs:
             console.log( objetivo_msg(6) )
             console.log( "» Analizando repo " + repo + " del usuario 🔥" + user )
             const all_checks_before_pag =
-                    await github.checks.listForRef.endpoint.merge(
+                    await github.rest.checks.listForRef.endpoint.merge(
                         { owner: user,
                           repo: repo,
                           ref: rama,
@@ -184,7 +184,7 @@ jobs:
             const all_checks = await github.paginate( all_checks_before_pag)
             console.log( "Checks → ", all_checks)
             const checks_before_pag =
-                    await github.checks.listForRef.endpoint.merge(
+                    await github.rest.checks.listForRef.endpoint.merge(
                         { owner: user,
                           repo: repo,
                           ref: rama,


### PR DESCRIPTION
# Fix en github-script workflow source-tests

## Primero y mas importante

* [x] NOCERRAR: No voy a cerrar ningún PR pase lo que pase. Ni voy a abrir otro
      para el mismo objetivo.

## Lista de comprobación para hitos

* [x] GUION: He leído el guión del hito
* [x] PRE: Cumplo los prerrequisitos (he aprobado el hito anterior, por ejemplo)

